### PR TITLE
Replace strings in `test_smschat.py` with variables

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length=140
+max-line-length=180


### PR DESCRIPTION
Refactored `test_smschat.py` to replace strings with variables to make the unit tests easier to read.