### PR TITLE
Send instructions for how to opt-out by responding with STOP

### DIFF
--- a/hotline/common_text.py
+++ b/hotline/common_text.py
@@ -27,6 +27,7 @@ sms_no_relays = "Sorry, there aren't any relays available to send your message. 
 sms_default_greeting = (
     "You have started a new chat with the organizers of {event.name}."
 )
-sms_introduction = "This is the beginning of a new chat for {event.name}, the last 4 digits of the reporter's number are {reporter_number}."
+sms_opt_out = "Reply STOP at any time to opt-out of receiving messages from this conversation."
+sms_introduction = "This is the beginning of a new chat for {event.name}, the last 4 digits of the reporter's number are {reporter_number}." + " " + sms_opt_out
 sms_stop_request_completed = "You've been successfully unsubscribed, you'll no longer receive messages from this number."
 sms_left_chat = "This participant has chosen to leave the chat."

--- a/hotline/telephony/smschat.py
+++ b/hotline/telephony/smschat.py
@@ -106,6 +106,9 @@ def _create_room(event_number: str, reporter_number: str) -> hotline.chatroom.Ch
     # Send welcome messages.
     lowlevel.send_sms(sender=event_number, to=reporter_number, message=greeting)
 
+    # Send instructions for how to opt-out by replying with STOP.
+    lowlevel.send_sms(sender=event_number, to=reporter_number, message=common_text.sms_opt_out)
+
     for organizer in organizers:
         lowlevel.send_sms(
             sender=relay_number,

--- a/tests/telephony/test_smschat.py
+++ b/tests/telephony/test_smschat.py
@@ -150,7 +150,7 @@ def test_handle_message_new_chat(send_sms, database):
     # The next two should have been sent to the two verified organizers to
     # introduce the chat.
     # The last two should relay the reporter's message.
-    assert send_sms.call_count == 5
+    assert send_sms.call_count == 6
     send_sms.assert_has_calls(
         [
             mock.call(
@@ -158,16 +158,24 @@ def test_handle_message_new_chat(send_sms, database):
                 to=REPORTER_NUMBER,
                 message=f"You have started a new chat with the organizers of {EVENT_NAME}.",
             ),
+            # The reporter should get a notice about how to opt out.
+            mock.call(
+                sender=EVENT_NUMBER,
+                to=REPORTER_NUMBER,
+                message="Reply STOP at any time to opt-out of receiving messages from this conversation.",
+            ),
             # The sender should be the *first available* relay number (1111)
             mock.call(
                 sender=RELAY_NUMBER,
                 to=BOB_ORGANIZER_NUMBER,
-                message=f"This is the beginning of a new chat for {EVENT_NAME}, the last 4 digits of the reporter's number are {REPORTER_NUMBER}.",
+                message=f"This is the beginning of a new chat for {EVENT_NAME}, the last 4 digits of the reporter's number are {REPORTER_NUMBER}. "
+                        "Reply STOP at any time to opt-out of receiving messages from this conversation.",
             ),
             mock.call(
                 sender=RELAY_NUMBER,
                 to=ALICE_ORGANIZER_NUMBER,
-                message=f"This is the beginning of a new chat for {EVENT_NAME}, the last 4 digits of the reporter's number are {REPORTER_NUMBER}.",
+                message=f"This is the beginning of a new chat for {EVENT_NAME}, the last 4 digits of the reporter's number are {REPORTER_NUMBER}. "
+                        "Reply STOP at any time to opt-out of receiving messages from this conversation.",
             ),
             mock.call(
                 sender=RELAY_NUMBER,


### PR DESCRIPTION
Send instructions for how to opt-out from the chat by responding with STOP to both participants and responders.

Follow up for PR #19 that implements #12 