### PR TITLE
Fix hotline calls coming from an unverified number

### DIFF
--- a/hotline/telephony/voice.py
+++ b/hotline/telephony/voice.py
@@ -80,12 +80,15 @@ def handle_inbound_call(
         }
     )
 
+    # Nexmo is apparently picky about + being in the from field.
+    from_number = event.primary_number.strip("+")
+
     # Add all of the event members to the conference call.
     for member in event_members:
         client.create_call(
             {
                 "to": [{"type": "phone", "number": member.number}],
-                "from": {"type": "phone", "number": event.primary_number},
+                "from": {"type": "phone", "number": from_number},
                 "answer_url": [
                     f"https://{host}/telephony/connect-to-conference/{conversation_uuid}/{call_uuid}"
                 ],

--- a/tests/telephony/test_voice.py
+++ b/tests/telephony/test_voice.py
@@ -37,7 +37,7 @@ def test_handle_inbound_call_no_event(database):
 
     ncco = voice.handle_inbound_call(
         reporter_number="1234",
-        event_number="5678",
+        event_number="+5678",
         conversation_uuid="conversation",
         call_uuid="call",
         host="example.com",
@@ -50,7 +50,7 @@ def test_handle_inbound_call_no_event(database):
 
 def create_event():
     number = db.Number()
-    number.number = "5678"
+    number.number = "+5678"
     number.country = "US"
     number.features = ""
     number.save()
@@ -76,7 +76,7 @@ def test_handle_inbound_call_blocked(database):
 
     ncco = voice.handle_inbound_call(
         reporter_number="1234",
-        event_number="5678",
+        event_number="+5678",
         conversation_uuid="conversation",
         call_uuid="call",
         host="example.com",
@@ -104,7 +104,7 @@ def test_handle_inbound_call_no_members(database):
 
     ncco = voice.handle_inbound_call(
         reporter_number="1234",
-        event_number="5678",
+        event_number="+5678",
         conversation_uuid="conversation",
         call_uuid="call",
         host="example.com",
@@ -139,7 +139,7 @@ def test_handle_inbound_call(database):
 
     ncco = voice.handle_inbound_call(
         reporter_number="1234",
-        event_number="5678",
+        event_number="+5678",
         conversation_uuid="conversation",
         call_uuid="call",
         host="example.com",
@@ -178,7 +178,7 @@ def test_handle_inbound_call_custom_greeting(database):
 
     ncco = voice.handle_inbound_call(
         reporter_number="1234",
-        event_number="5678",
+        event_number="+5678",
         conversation_uuid="conversation",
         call_uuid="call",
         host="example.com",
@@ -194,7 +194,7 @@ def test_handle_member_answer_no_event(database):
     nexmo_client = mock.create_autospec(nexmo.Client)
 
     ncco = voice.handle_member_answer(
-        event_number="5678",
+        event_number="+5678",
         member_number="202",
         origin_conversation_uuid="conversation",
         origin_call_uuid="call",
@@ -213,7 +213,7 @@ def test_handle_member_answer(database):
     nexmo_client = mock.create_autospec(nexmo.Client)
 
     ncco = voice.handle_member_answer(
-        event_number="5678",
+        event_number="+5678",
         member_number="202",
         origin_conversation_uuid="conversation",
         origin_call_uuid="call",


### PR DESCRIPTION
Nexmo expects the from number to contain no leading zeros and no additional characters. 

Stripping the `+` from the from number means the call will come from the hotline number, instead of coming from an unverified number. 